### PR TITLE
Add save/restore logic

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -33,7 +33,7 @@ MidiChordsAudioProcessorEditor::MidiChordsAudioProcessorEditor (MidiChordsAudioP
     addAndMakeVisible(&options);
     addAndMakeVisible(&chordView);
 
-    Timer::startTimer(100);
+    Timer::startTimer(1000);
 }
 
 MidiChordsAudioProcessorEditor::~MidiChordsAudioProcessorEditor()
@@ -67,7 +67,12 @@ void MidiChordsAudioProcessorEditor::timerCallback()
         vector<int> itNotes = ms->getAllNotesOnAtTime(0, *i);
         lastChord = cn.nameChord(itNotes);
         if (lastChord != "") 
-            info += lastChord + ", ";
+        {
+            double seconds = ms->getEventTimeInSeconds(*i);
+            ostringstream oss;
+            oss << info << lastChord << " (" << *i << ", " << seconds << "), ";
+            info = oss.str();
+        }
     }
     currentChords.setText("all chords: " + info, juce::NotificationType::sendNotification);
 

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -267,12 +267,22 @@ void MidiChordsAudioProcessor::getStateInformation (juce::MemoryBlock& destData)
     // You should use this method to store your parameters in the memory block.
     // You could do that either as raw data, or use the XML or ValueTree classes
     // as intermediaries to make it easy to save and load complex data.
+    ValueTree &vt = this->referenceTrack.getState();
+    std::unique_ptr<juce::XmlElement> xml(vt.createXml());
+    copyXmlToBinary(*xml, destData);
 }
 
 void MidiChordsAudioProcessor::setStateInformation (const void* data, int sizeInBytes)
 {
     // You should use this method to restore your parameters from this memory block,
     // whose contents will have been created by the getStateInformation() call.
+    std::unique_ptr<juce::XmlElement> xmlState(getXmlFromBinary(data, sizeInBytes));
+
+    if (xmlState.get() != nullptr)
+    {
+        auto restored = juce::ValueTree::fromXml(*xmlState);
+        this->referenceTrack.replaceState(restored);
+    }
 }
 
 //==============================================================================

--- a/tests/chordClipperTest.cpp
+++ b/tests/chordClipperTest.cpp
@@ -8,6 +8,7 @@ using namespace std;
 TEST_CASE("chord view empty", "chordview")
 {
     MidiStore ms;
+    ms.setQuantizationValue(1);
     ChordClipper cp(ms);
     map<float, string> display;
 
@@ -19,6 +20,7 @@ TEST_CASE("chord view empty", "chordview")
 TEST_CASE("chord view window", "chordview")
 {
     MidiStore ms;
+    ms.setQuantizationValue(1);
 
     // Note - The relative event times and times in seconds are not relative. The ones that
     // matter here are the seconds. The integer event times just need to be incrementing


### PR DESCRIPTION
#what Add save and restore logic
#why Important bit of functionality since I can't read the entire track. Have to play it at least once to gather the data.
This allows someone to do that "once" and then it will be saved and just be available for future playbacks.

Misc changes:
 - Added some rounding (quantization of sorts) to the event times. I noticed that playback produces slightly different values sometimes. For this plugin, a few milliseconds one way or the other doesn't matter. This ensures that the notes don't get duplicated.
 - Change the note storage props in the value tree to have a valid xml name (":midinoteval" instead of just the integer). This allows the save/restore xml conversion to work without assertion failures. And ... it's mo' better and correct.