### PR TITLE
Improve performance of playback

### DIFF
--- a/src/ChordClipper.cpp
+++ b/src/ChordClipper.cpp
@@ -44,31 +44,24 @@ void ChordClipper::updateCurrentPosition(int msSinceLastUpdate)
  * floating point time in seconds is the time relative to the window. (e.g., where 0 is the left-most
  * side of the window)
  * 
- * @return map<float, string> 
+ * @return vector<pair<float, string>>
  */
-map<float, string> ChordClipper::getChordsToDisplay() 
+vector<pair<float, string>> ChordClipper::getChordsToDisplay() 
 {
     // Compute the view window for the chords of interest
     pair<float, float> viewWindow = getViewWindowSize();
-    map<float, string> chords;
-    ChordName cn;
+    vector<pair<float, string>> chords;
+    float offset = viewWindow.first;
 
-    vector<int64> eventTimes = midiState.getEventTimes();
-    for (vector<int64>::iterator i = eventTimes.begin(); i != eventTimes.end(); ++i) 
-    {
-        float eventSeconds = static_cast<float>(midiState.getEventTimeInSeconds(*i));
-        float relativePosition;
-        if (isEventInWindow(viewWindow, eventSeconds, relativePosition))
-        {
-            vector<int> itNotes = midiState.getAllNotesOnAtTime(0, *i);
-            if (itNotes.size() > 0)
-            {
-                string chord = cn.nameChord(itNotes);
-                chords.insert({relativePosition, chord});
-            }
+    viewWindow.first -= 2.0f;
+    viewWindow.second += 2.0f;
+    chords = midiState.getChordsInWindow(viewWindow);
+    // need to offset the values to the window. If the window is 50 to 70, and we have events
+    // at 55 and 56, then we want to change them to be 5 and 6 respectively (make their offsets
+    // be relative to the window)
+    for (auto &i : chords) 
+        i.first -= offset;
 
-        }
-    }
     return chords;
 }
 

--- a/src/ChordClipper.h
+++ b/src/ChordClipper.h
@@ -25,7 +25,7 @@ class ChordClipper
 {
 public:
     ChordClipper(MidiStore&);
-    map<float, string> getChordsToDisplay();
+    vector<pair<float, string>> getChordsToDisplay();
     void updateCurrentPosition(int msSinceLastUpdate);
 
     float getViewWidthInSeconds() {return viewWidthInSeconds;}

--- a/src/ChordView.cpp
+++ b/src/ChordView.cpp
@@ -41,7 +41,7 @@ void ChordView::paint(juce::Graphics &g)
 
     g.setColour(getLookAndFeel().findColour(juce::Slider::thumbColourId));
     // map<float, string> chords = this->getChordsToDisplay();
-    map<float, string> chords = chordClipper.getChordsToDisplay();
+    vector<pair<float, string>> chords = chordClipper.getChordsToDisplay();
     this->drawChords(chords, g);
 }
 
@@ -52,16 +52,16 @@ void ChordView::paint(juce::Graphics &g)
  * @param chords   map of chords by time relative to the window
  * @param g 
  */
-void ChordView::drawChords(map<float, string> chords, juce::Graphics &g)
+void ChordView::drawChords(vector<pair<float, string>> chords, juce::Graphics &g)
 {
-    map<float, string>::iterator it;
+    // map<float, string>::iterator it;
     auto area = getLocalBounds();
     juce::Rectangle<float> textBox;
     textBox = area.toFloat();
     g.setFont(25.0);
     float ratio = textBox.getWidth() / chordClipper.getViewWidthInSeconds();
 
-    for (it = chords.begin(); it != chords.end(); ++it)
+    for (auto it = chords.begin(); it != chords.end(); ++it)
     {
         float leftPos = it->first * ratio;
         textBox.setLeft(leftPos);

--- a/src/ChordView.h
+++ b/src/ChordView.h
@@ -38,7 +38,7 @@ public:
 
 private:
     ChordClipper chordClipper;
-    void drawChords(map<float, string> chords, juce::Graphics &g);
+    void drawChords(vector<pair<float, string>> chords, juce::Graphics &g);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ChordView)
 };

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -24,16 +24,16 @@ MidiChordsAudioProcessorEditor::MidiChordsAudioProcessorEditor (MidiChordsAudioP
 
 
     lastTimeStamp.setColour(juce::Label::ColourIds::textColourId, juce::Colours::black);
-    lastChordSeen.setColour(juce::Label::ColourIds::textColourId, juce::Colours::black);
+    debugInfo1.setColour(juce::Label::ColourIds::textColourId, juce::Colours::black);
     currentChords.setColour(juce::Label::ColourIds::textColourId, juce::Colours::black);
 
     addAndMakeVisible(&lastTimeStamp);
-    addAndMakeVisible(&lastChordSeen);
+    addAndMakeVisible(&debugInfo1);
     addAndMakeVisible(&currentChords);
     addAndMakeVisible(&options);
     addAndMakeVisible(&chordView);
 
-    Timer::startTimer(1000);
+    Timer::startTimer(500);
 }
 
 MidiChordsAudioProcessorEditor::~MidiChordsAudioProcessorEditor()
@@ -55,11 +55,12 @@ void MidiChordsAudioProcessorEditor::timerCallback()
     repaint();
 
     std::string info = "";
+
     MidiStore *ms = audioProcessor.getReferenceTrack();
-    vector<int> currentNotes = ms->getAllNotesOnAtTime(0, audioProcessor.lastEventTimestamp);
-    ChordName cn;
-    string lastChord = cn.nameChord(currentNotes);
-    lastChordSeen.setText("latest Chord: " + lastChord, juce::NotificationType::sendNotification);
+    ms->updateStaticViewIfOutOfDate();
+
+    debugInfo1.setText("visible chord count: " + std::to_string(ms->getViewWindowChordCount()), juce::NotificationType::sendNotification);
+    /*
     std::vector<int64> eventTimes = ms->getEventTimes();
     for (std::vector<int64>::iterator i = eventTimes.begin(); i != eventTimes.end(); ++i) 
     {
@@ -75,6 +76,7 @@ void MidiChordsAudioProcessorEditor::timerCallback()
         }
     }
     currentChords.setText("all chords: " + info, juce::NotificationType::sendNotification);
+    */
 
 
 }
@@ -96,7 +98,7 @@ void MidiChordsAudioProcessorEditor::resized()
 {
     // sets the position and size of the slider with arguments (x, y, width, height)
     lastTimeStamp.setBounds(10, 10, 100, 30);
-    lastChordSeen.setBounds(10, 40, 100, 30);
+    debugInfo1.setBounds(10, 40, getWidth() - 10, 30);
     currentChords.setBounds(10, 70, getWidth() - 10, 60);
     options.setBounds(0, getHeight() - 100, getWidth(), 100);
     chordView.setBounds(0, getHeight() - 200, getWidth(), 100);

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -36,7 +36,7 @@ private:
 
     juce::Label currentChords;
     juce::Label lastTimeStamp;
-    juce::Label lastChordSeen;
+    juce::Label debugInfo1;
     OptionsComponent options;
     ChordView chordView;
 

--- a/tests/chordClipperTest.cpp
+++ b/tests/chordClipperTest.cpp
@@ -10,7 +10,7 @@ TEST_CASE("chord view empty", "chordview")
     MidiStore ms;
     ms.setQuantizationValue(1);
     ChordClipper cp(ms);
-    map<float, string> display;
+    vector<pair<float, string>> display;
 
     display = cp.getChordsToDisplay();
     REQUIRE(display.size() == 0);
@@ -28,20 +28,25 @@ TEST_CASE("chord view window", "chordview")
     ms.addNoteEventAtTime(50, 12, true);
     ms.setEventTimeSeconds(50, 5.0);
     ms.addNoteEventAtTime(60, 12, false);
+    ms.setEventTimeSeconds(60, 5.5);
 
     // F
     ms.addNoteEventAtTime(100, 17, true);
     ms.setEventTimeSeconds(100, 15.0);
     ms.addNoteEventAtTime(110, 17, false);
+    ms.setEventTimeSeconds(110, 15.5);
 
     // G
     ms.addNoteEventAtTime(200, 19, true);
     ms.setEventTimeSeconds(200, 30.0);
     ms.addNoteEventAtTime(210, 19, false);
+    ms.setEventTimeSeconds(210, 32.0);
+
+    ms.updateStaticViewIfOutOfDate();
 
     ChordClipper cp(ms);
-    map<float, string> chords;
-    map<float, string> expected;
+    vector<pair<float, string>> chords;
+    vector<pair<float, string>> expected;
 
     chords = cp.getChordsToDisplay();
     // The expected chords are offset by "current note position" ... the default is to have the currently


### PR DESCRIPTION
Improve the playback performance. Created a sorted vector of time/chord to be the reference for playback view.
Only refresh it when data is changed and only once per second at most. This makes a vast improvement in the
playback smoothness. It is able to search efficiently for the position in the view window and quickly grab those
notes. 

Changes included and related:
- Put the update of the static view in the timer callback in the editor
- Important note: I removed the "show all chords" debug information that was using the getallnotesonattime ... that was very costly and caused delays and clicks in playback. Probably can remove that method now. Unless it is useful for testing.
- Track if the midistate is updated or not. That allows me to only update the static view if needed. 