### PR TITLE
Add playhead position and time width controls

### DIFF
--- a/src/ChordClipper.h
+++ b/src/ChordClipper.h
@@ -28,8 +28,8 @@ public:
     vector<pair<float, string>> getChordsToDisplay();
     void updateCurrentPosition(int msSinceLastUpdate);
 
-    float getViewWidthInSeconds() {return viewWidthInSeconds;}
-    float getCurrentNotePosition() {return currentNotePosition;}
+    float getViewWidthInSeconds();
+    float getCurrentNotePosition();
 
 private:
 
@@ -42,12 +42,6 @@ private:
     // This represents where we believe the playhead to be. Tracking this value instead of pestering the audio processor
     // for actual playhead position constantly
     atomic<float> estimatedPlayPosition = 0.0;
-
-    float viewWidthInSeconds = 20.0;
-    // Reference position of "now" in the view port. This is where in the current position of the playhead resides.
-    // In other words, if window width represents 20 seconds and this is value 5, then the currently playing note (chord)
-    // will be at 25% from the left.
-    float currentNotePosition = 5.0;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ChordClipper)
 };

--- a/src/MidiStore.h
+++ b/src/MidiStore.h
@@ -48,6 +48,10 @@ public:
     inline static const char* eventTimeInSecondsProp = "eventTimeInSeconds";
     inline static const char* eventTimeProp = "eventTime";
     inline static const char* quantizationValueProp = "quantizationValue";
+    inline static const char* allowRecordingProp = "allowRecording";
+    // property with the position of the playhead in % (within the view window)
+    inline static const char* playHeadPositionProp = "playheadPosition";
+    inline static const char* viewWidthProp = "viewWidthProp";
 
     
 
@@ -65,6 +69,9 @@ public:
     bool replaceState(ValueTree &newState);
     // -------------------------
 
+    ValueTree& getState() {return this->chordState;}
+
+
     void updateStaticView();
     void updateStaticViewIfOutOfDate();
     vector<int> getNoteOnEventsAtTime(int64 time);
@@ -74,8 +81,14 @@ public:
     vector<pair<float, string>> getChordsInWindow(pair<float, float> viewWindow);
     int getViewWindowChordCount() {return viewWindowChordCount;}
     void clear();
-    void allowStateChange(bool allow) {allowDataRecording = allow;}
-    bool getRecordingState() {return allowDataRecording;}
+    void allowStateChange(bool allow);
+    void setPlayHeadPosition(float percentage);
+    float getPlayHeadPosition();
+
+    void setTimeWidth(float width);
+    float getTimeWidth();
+
+    bool getRecordingState() { return allowDataRecording; }
 
     // setters/getters for most recently seen event time
     void setLastEventTime(int64 time) {lastEventTime = time;}
@@ -85,8 +98,6 @@ public:
 
     void setIsPlaying(bool playing) {isPlaying = playing;}
     bool getIsPlaying() {return isPlaying;}
-
-    ValueTree& getState() {return this->chordState;}
 
     int getQuantizationValue();
     void setQuantizationValue(int q);
@@ -99,10 +110,16 @@ private:
     CriticalSection storeLock;
     // This is a lock on the static view that is used for the common usages of viewing chords
     CriticalSection viewLock;
+    // the bulk of the data is stored in this value tree. It, effectively, represents the entire
+    // state of the plugin (mostly the midi notes that have been played in the track)
+    juce::ValueTree chordState;
+
     // Is the static view of the chords up to date?
     bool isViewUpToDate = false;
     int64 lastViewUpdateTime = 0;
     int viewWindowChordCount = 0;
+
+    void refreshSettingsFromState();
     
     vector<pair<float, string>> staticView;
     // If this is true, then save state changes. Otherwise, don't
@@ -140,8 +157,5 @@ private:
 
     int64 findMaxTime();
 
-    // the bulk of the data is stored in this value tree. It, effectively, represents the entire
-    // state of the plugin (mostly the midi notes that have been played in the track)
-    juce::ValueTree chordState;
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MidiStore)
 };

--- a/src/OptionsComponent.cpp
+++ b/src/OptionsComponent.cpp
@@ -3,11 +3,10 @@
  * @author Mark Wilkins
  * @brief Part of MidiChords project (plugin to display chord names from a MIDI track on playback)
  * @version 0.1
- * 
+ *
  * @copyright Copyright (c) 2023
- * 
+ *
  */
-
 
 #include "OptionsComponent.h"
 
@@ -16,17 +15,39 @@ using namespace juce;
 OptionsComponent::OptionsComponent(MidiStore &ms) : midiState(ms)
 {
     propsPanel.setColour(juce::GroupComponent::ColourIds::outlineColourId, juce::Colours::darkgrey);
-    propsPanel.addChildComponent(&resetChords);
+    // propsPanel.addChildComponent(&resetChordsButton);
     addAndMakeVisible(propsPanel);
-    resetChords.setButtonText("Clear Notes!");
-    propsPanel.addAndMakeVisible(&resetChords);
-    recordingOn.setButtonText("Record Notes");
-    propsPanel.addAndMakeVisible(&recordingOn);
+    recordingOnToggle.setButtonText("Record Notes");
+    propsPanel.addAndMakeVisible(&recordingOnToggle);
+    resetChordsButton.setButtonText("Clear Notes!");
+    propsPanel.addAndMakeVisible(&resetChordsButton);
+
+    // juce tutorial of interest:  https://docs.juce.com/master/tutorial_slider_values.html
+    propsPanel.addAndMakeVisible(&positionOfPlayheadSlider);
+    positionOfPlayheadSlider.setRange(1.0, 99.0, 1.0);
+    positionOfPlayheadSlider.setTextValueSuffix(" %");
+
+    // The number of seconds represented by the window
+    propsPanel.addAndMakeVisible(&timeWidthSlider);
+    timeWidthSlider.setRange(4.0, 30.0, 1.0);
+    timeWidthSlider.setTextValueSuffix(" sec");
 
     // click handler lambdas
-    resetChords.onClick = [this] { resetClick(); };
-    recordingOn.onStateChange = [this] {recordingClick(recordingOn.getToggleState()); };
-    recordingOn.setToggleState(ms.getRecordingState(), juce::sendNotification);
+    resetChordsButton.onClick = [this] { resetClick(); };
+    recordingOnToggle.onStateChange = [this] { recordingClick(recordingOnToggle.getToggleState()); };
+    recordingOnToggle.setToggleState(ms.getRecordingState(), juce::sendNotification);
+
+    positionOfPlayheadSlider.onValueChange = [this] { adjustPositionPlayhead(positionOfPlayheadSlider.getValue()); };
+    positionOfPlayheadSlider.setValue(ms.getPlayHeadPosition(), juce::sendNotification);
+    playheadLabel.attachToComponent(&positionOfPlayheadSlider, true);
+    addAndMakeVisible(playheadLabel);
+    playheadLabel.setText("Playhead", juce::dontSendNotification);
+
+    timeWidthSlider.onValueChange = [this] { adjustTimeWidth(timeWidthSlider.getValue()); };
+    timeWidthSlider.setValue(ms.getTimeWidth(), juce::sendNotification);
+    timeWidthLabel.attachToComponent(&timeWidthSlider, true);
+    addAndMakeVisible(timeWidthLabel);
+    timeWidthLabel.setText("View Seconds", juce::dontSendNotification);
 }
 
 /**
@@ -36,6 +57,27 @@ void OptionsComponent::resetClick()
 {
     DBG("Reset click happened");
     midiState.clear();
+}
+
+/**
+ * @brief Update the controls to the current settings in the state tre
+ */
+void OptionsComponent::refreshControlState()
+{
+    recordingOnToggle.setToggleState(midiState.getRecordingState(), juce::sendNotification);
+    positionOfPlayheadSlider.setValue(midiState.getPlayHeadPosition(), juce::sendNotification);
+    timeWidthSlider.setValue(midiState.getTimeWidth(), juce::sendNotification);
+}
+
+// Handlers for changes in the settings (update the state tree with the info)
+void OptionsComponent::adjustPositionPlayhead(double value)
+{
+    midiState.setPlayHeadPosition(static_cast<float>(value));
+}
+
+void OptionsComponent::adjustTimeWidth(double value)
+{
+    midiState.setTimeWidth(static_cast<float>(value));
 }
 
 void OptionsComponent::recordingClick(bool state)
@@ -51,10 +93,15 @@ void OptionsComponent::paint(juce::Graphics &g) // override
 void OptionsComponent::resized() // override
 {
     auto area = getLocalBounds();
-    int  buttonHeight = 40;
+    int buttonHeight = 40;
+    int column;
 
     propsPanel.setBounds(area);
-    resetChords.setBounds(20, area.getHeight() / 2 - buttonHeight / 2, 100, buttonHeight);
-    recordingOn.setBounds(resetChords.getBounds().getWidth() + 40, area.getHeight() / 2 - buttonHeight / 2, 100, buttonHeight);
+    // recordingOnToggle.setBounds(resetChordsButton.getBounds().getWidth() + 40, area.getHeight() / 2 - buttonHeight / 2, 100, buttonHeight);
+    recordingOnToggle.setBounds(20, area.getHeight() / 3 - buttonHeight / 2, 100, buttonHeight);
+    resetChordsButton.setBounds(20, area.getHeight() * 2 / 3 - buttonHeight / 2, 100, buttonHeight);
 
+    column = resetChordsButton.getBounds().getWidth() + 150;
+    positionOfPlayheadSlider.setBounds(column, area.getHeight() / 3 - buttonHeight / 2, 200, buttonHeight);
+    timeWidthSlider.setBounds(column, area.getHeight() * 2 / 3 - buttonHeight / 2, 200, buttonHeight);
 }

--- a/src/OptionsComponent.h
+++ b/src/OptionsComponent.h
@@ -24,12 +24,21 @@ public:
 
     void resetClick();
 
+    void adjustPositionPlayhead(double value);
+    void adjustTimeWidth(double value);
+
     void recordingClick(bool state);
+
+    void refreshControlState();
 
 private:
     juce::GroupComponent propsPanel;
-    juce::TextButton resetChords;
-    juce::ToggleButton recordingOn;
+    juce::TextButton resetChordsButton;
+    juce::ToggleButton recordingOnToggle;
+    juce::Label playheadLabel;
+    juce::Slider positionOfPlayheadSlider;
+    juce::Label timeWidthLabel;
+    juce::Slider timeWidthSlider;
     void paint(juce::Graphics &g) override;
     MidiStore &midiState;
 

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -20,7 +20,7 @@ MidiChordsAudioProcessorEditor::MidiChordsAudioProcessorEditor (MidiChordsAudioP
     : AudioProcessorEditor (&p), juce::Timer(), audioProcessor (p), options(ms), chordView(ms)
 {
     setResizable(true, true);
-    setSize (600, 400);
+    setSize (1000, 400);
 
 
     lastTimeStamp.setColour(juce::Label::ColourIds::textColourId, juce::Colours::black);
@@ -32,6 +32,7 @@ MidiChordsAudioProcessorEditor::MidiChordsAudioProcessorEditor (MidiChordsAudioP
     addAndMakeVisible(&currentChords);
     addAndMakeVisible(&options);
     addAndMakeVisible(&chordView);
+
 
     Timer::startTimer(500);
 }
@@ -48,10 +49,28 @@ void MidiChordsAudioProcessorEditor::timerCallback()
     for (it = audioProcessor.currentNotes.begin(); it != audioProcessor.currentNotes.end(); it++) {
         text = text + " " + *it;
     }
-    
+
+    // The setDirty method for vst3 has this bit of code for setting dirty. I don't think it works, but leaving
+    // it here for further testing when I feel like it. If I figure out that it does work, then I need to set
+    // this when actual changes occur (e.g., when isViewUpToDate is set to false and for props like allowStateChange)
+    // this->audioProcessor.updateHostDisplay(AudioPluginInstance::ChangeDetails{}.withNonParameterStateChanged(true));
+
     juce::String lastTime = std::to_string(audioProcessor.lastEventTime);
     juce::String lastTimestampValue = std::to_string((int64)(audioProcessor.lastEventTimestamp));
     lastTimeStamp.setText("lasttime: " + lastTimestampValue, juce::NotificationType::sendNotification);
+
+    // This is very cheesy - refresh the control settings in case the state has changed. I need to figure
+    // out the listener stuff better. But there are very few controls, so not expensive
+    // Current thinking for better solution:
+    //  - Add a new child valuetree in the main state tree that stores prop values (e.g., scroll view window width, playhead position)
+    //  - Put a broadcaster on that tree; then it should be efficient and not trigger for any of the other tree changes (e.g., new notes)
+    //  - Add a listener for those state changes and call the refreshControlState
+    //  - The tricky bit is that I blow away the entire state tree on the load of the state (in PluginProcessor.cpp). I would
+    //    need to somehow reestablish that listener. Or maybe just move that props child tree to the new tree. A valuetree can
+    //    have only one parent, so I suspect that is a simple operation.
+    options.refreshControlState();
+
+    // and I cannot remember why this repaint call is here. Early version from one of the tutorials? Is it still needed?
     repaint();
 
     std::string info = "";


### PR DESCRIPTION
#what Add editor controls (sliders) for setting the position of the playhead (the now position in the window) and the width of the window in seconds. Updated it to keep that data in the state tree.