### PR TITLE
Remove short chords from display

### DIFF
--- a/src/ChordClipper.cpp
+++ b/src/ChordClipper.cpp
@@ -73,6 +73,12 @@ vector<pair<float, string>> ChordClipper::getChordsToDisplay()
     vector<pair<float, string>> chords;
     float offset = viewWindow.first;
 
+    // TODO: efficiency change:
+    // Maintain state info in this class of current chords being displayed. And then here, we should be able to
+    // just get new chords once every second perhaps (since we have the 2 second buffer). That way, if we already
+    // have chords for time T 20 to 30 and then when we are asking for chords from 21 to 31, we should need only
+    // to get the chords for time T 30 to 31 and just update the existing set.
+
     viewWindow.first -= 2.0f;
     viewWindow.second += 2.0f;
     chords = midiState.getChordsInWindow(viewWindow);

--- a/src/MidiStore.h
+++ b/src/MidiStore.h
@@ -52,6 +52,7 @@ public:
     // property with the position of the playhead in % (within the view window)
     inline static const char* playHeadPositionProp = "playheadPosition";
     inline static const char* viewWidthProp = "viewWidthProp";
+    inline static const char* shortChordThresholdProp = "shortChordThresholdProp";
 
     
 
@@ -87,6 +88,8 @@ public:
 
     void setTimeWidth(float width);
     float getTimeWidth();
+    void setShortChordThreshold(float threshold);
+    float getShortChordThreshold();
 
     bool getRecordingState() { return allowDataRecording; }
 
@@ -120,7 +123,10 @@ private:
     int viewWindowChordCount = 0;
 
     void refreshSettingsFromState();
-    
+
+    void setStateProp(const char *propName, juce::var value);
+    float getStateFloatProp(const char *propName, float defaultValue, float min, float max);
+
     vector<pair<float, string>> staticView;
     // If this is true, then save state changes. Otherwise, don't
     // mlwtbd - I think I want this false by default for typical usage ... or maybe it just needs to be stored with the
@@ -147,6 +153,8 @@ private:
     int64 maxTimeStored = 0;
 
     vector <pair<float, string>> createStaticView();
+    vector<pair<float, string>> getChordsInWindowRaw(pair<float, float> viewWindow);
+    void removeShortChords(vector<pair<float, string>> &view);
     void updateCurrentlyOn(ValueTree &childEvents, set<int> &notes, int propIndex);
     Identifier noteIdentFromInt(int note);
     int64 quantizeEventTime(int64 time);

--- a/src/OptionsComponent.cpp
+++ b/src/OptionsComponent.cpp
@@ -15,8 +15,9 @@ using namespace juce;
 OptionsComponent::OptionsComponent(MidiStore &ms) : midiState(ms)
 {
     propsPanel.setColour(juce::GroupComponent::ColourIds::outlineColourId, juce::Colours::darkgrey);
-    // propsPanel.addChildComponent(&resetChordsButton);
+
     addAndMakeVisible(propsPanel);
+
     recordingOnToggle.setButtonText("Record Notes");
     propsPanel.addAndMakeVisible(&recordingOnToggle);
     resetChordsButton.setButtonText("Clear Notes!");
@@ -26,11 +27,25 @@ OptionsComponent::OptionsComponent(MidiStore &ms) : midiState(ms)
     propsPanel.addAndMakeVisible(&positionOfPlayheadSlider);
     positionOfPlayheadSlider.setRange(1.0, 99.0, 1.0);
     positionOfPlayheadSlider.setTextValueSuffix(" %");
+    playheadLabel.attachToComponent(&positionOfPlayheadSlider, true);
+    propsPanel.addAndMakeVisible(playheadLabel);
+    playheadLabel.setText("Playhead", juce::dontSendNotification);
 
     // The number of seconds represented by the window
     propsPanel.addAndMakeVisible(&timeWidthSlider);
     timeWidthSlider.setRange(4.0, 30.0, 1.0);
     timeWidthSlider.setTextValueSuffix(" sec");
+    timeWidthLabel.attachToComponent(&timeWidthSlider, true);
+    propsPanel.addAndMakeVisible(timeWidthLabel);
+    timeWidthLabel.setText("View Seconds", juce::dontSendNotification);
+
+    // Minimum width (in seconds) for chords to display
+    propsPanel.addAndMakeVisible(&shortChordSlider);
+    shortChordSlider.setRange(0.0, 2.5, 0.1);
+    shortChordSlider.setTextValueSuffix(" sec");
+    shortChordLabel.attachToComponent(&shortChordSlider, true);
+    propsPanel.addAndMakeVisible(shortChordLabel);
+    shortChordLabel.setText("Minimum chord", juce::dontSendNotification);
 
     // click handler lambdas
     resetChordsButton.onClick = [this] { resetClick(); };
@@ -39,15 +54,12 @@ OptionsComponent::OptionsComponent(MidiStore &ms) : midiState(ms)
 
     positionOfPlayheadSlider.onValueChange = [this] { adjustPositionPlayhead(positionOfPlayheadSlider.getValue()); };
     positionOfPlayheadSlider.setValue(ms.getPlayHeadPosition(), juce::sendNotification);
-    playheadLabel.attachToComponent(&positionOfPlayheadSlider, true);
-    addAndMakeVisible(playheadLabel);
-    playheadLabel.setText("Playhead", juce::dontSendNotification);
 
     timeWidthSlider.onValueChange = [this] { adjustTimeWidth(timeWidthSlider.getValue()); };
     timeWidthSlider.setValue(ms.getTimeWidth(), juce::sendNotification);
-    timeWidthLabel.attachToComponent(&timeWidthSlider, true);
-    addAndMakeVisible(timeWidthLabel);
-    timeWidthLabel.setText("View Seconds", juce::dontSendNotification);
+
+    shortChordSlider.onValueChange = [this] { adjustShortChordThreshold(shortChordSlider.getValue()); };
+    shortChordSlider.setValue(ms.getShortChordThreshold(), juce::sendNotification);
 }
 
 /**
@@ -80,6 +92,11 @@ void OptionsComponent::adjustTimeWidth(double value)
     midiState.setTimeWidth(static_cast<float>(value));
 }
 
+void OptionsComponent::adjustShortChordThreshold(double value)
+{
+    midiState.setShortChordThreshold(static_cast<float>(value));
+}
+
 void OptionsComponent::recordingClick(bool state)
 {
     midiState.allowStateChange(state);
@@ -104,4 +121,7 @@ void OptionsComponent::resized() // override
     column = resetChordsButton.getBounds().getWidth() + 150;
     positionOfPlayheadSlider.setBounds(column, area.getHeight() / 3 - buttonHeight / 2, 200, buttonHeight);
     timeWidthSlider.setBounds(column, area.getHeight() * 2 / 3 - buttonHeight / 2, 200, buttonHeight);
+
+    column += positionOfPlayheadSlider.getBounds().getWidth() + 150;
+    shortChordSlider.setBounds(column, area.getHeight() / 3 - buttonHeight / 2, 200, buttonHeight);
 }

--- a/src/OptionsComponent.h
+++ b/src/OptionsComponent.h
@@ -26,6 +26,7 @@ public:
 
     void adjustPositionPlayhead(double value);
     void adjustTimeWidth(double value);
+    void adjustShortChordThreshold(double value);
 
     void recordingClick(bool state);
 
@@ -39,6 +40,8 @@ private:
     juce::Slider positionOfPlayheadSlider;
     juce::Label timeWidthLabel;
     juce::Slider timeWidthSlider;
+    juce::Label shortChordLabel;
+    juce::Slider shortChordSlider;
     void paint(juce::Graphics &g) override;
     MidiStore &midiState;
 


### PR DESCRIPTION
#what Add logic (and UI control) to not display chords that are under a certain threshold
#why A busy score might be changing chords very rapidly. But for my needs, I don't want to see a chord that lasts only a fraction of a second. I'm not going to try to play that if I am following along. Plus, I'm not even sure how to display it when there is a mass of chords like that.