### PR TITLE
Display sharp/flat with unicode symbols

### DIFF
--- a/src/ChordName.cpp
+++ b/src/ChordName.cpp
@@ -232,27 +232,14 @@ string ChordName::midiNoteToName(int note)
     return "unknown note";
 }
 
-/*
-string ChordName::midiNoteToNameFirstCut(int note, string key)
-{
-    bool isSharpKey;
-    bool isMinor;
 
-    // Normalize to values 0 to 11 (0 is C, ... 11 is B)
-    note %= 12;
-    auto it = chordMap.find(note);
-    if (it != chordMap.end())
-    {
-        pair<int, chordInfo> ci = *it;
-        bool isSharp = ci.second.isSharp;
-
-    }
-
-    return "";
-
-}
-*/
-
+/**
+ * @brief Determine if a given key is one of the "sharp" keys (e.g., a key that has the
+ * black notes typically represented as sharps)
+ * 
+ * @param string key 
+ * @return bool
+ */
 bool ChordName::isSharpKey(string key)
 {
     auto it = chordLookup.find(key);
@@ -262,6 +249,21 @@ bool ChordName::isSharpKey(string key)
         return ci.second.isSharp;
     }
 
-    // Maybe should log something here
+    // Maybe should log something here ... it means we don't have the key in our map
     return true;
+}
+
+
+/**
+ * @brief Retrieve the unicode symbol for a given character (e.g., map b to the unicode flat symbol)
+ * 
+ * @param c 
+ * @return optional<string> 
+ */
+optional<string> ChordName::getUnicodeSymbol(char c) {
+    auto symbol = musicSymbolLookup.find(c);
+    if (symbol != musicSymbolLookup.end()) 
+        return symbol->second;
+    else
+        return nullopt;
 }

--- a/src/ChordName.h
+++ b/src/ChordName.h
@@ -36,6 +36,7 @@ public:
 
     string nameChord(vector<int> notes);
     string midiNoteToName(int note);
+    optional<string> getUnicodeSymbol(char c);
 
     // These "maybe" should be private methods. But 
     bool normalizeNotes(vector<int> &notes);
@@ -46,6 +47,7 @@ private:
     string twoNoteChordName(vector<int> notes);
     string multiNoteChordName(vector<int> notes);
     bool isSharpKey(string key);
+
 
     // one could have semantic arguments about these, but the F# vs Gb one is probably the main one
     // that seems like it could be argued either way. Going with the flat option for now (gives 6 for each)
@@ -63,7 +65,7 @@ private:
     {
         {1, ""},
         {2, "2"},
-        {3, "min"},
+        {3, "m"},
         {4, ""},
         {5, "4"},
         {6, ""},   // not really sure what this would be. C+F# for example. Dunno
@@ -80,7 +82,7 @@ private:
     inline static const map<tuple<int, int, int>, string> chordQuality = 
     {
         {{4, 3, 0}, ""},     // Could include "maj" here ... but I don't want to see "maj" on every one of these
-        {{3, 4, 0}, "min"},
+        {{3, 4, 0}, "m"},
         {{3, 3, 0}, "dim"},
         {{4, 4, 0}, "aug"},
         {{4, 3, 3}, "7"},   // dominant 7th
@@ -93,7 +95,14 @@ private:
         
     };
 
-    // TODO: still need to determine if F# or Gb
+    // map flat and sharp to the unicode symbol
+    inline static const map<char, string> musicSymbolLookup = {
+        {'b', "\xe2\x99\xad"},   // flat
+        {'n', "\xe2\x99\xae"},   // natural
+        {'#', "\xe2\x99\xaf"},   // sharp
+
+    };
+
     inline static const map<int, string> midiNoteLookup = {
         {0, "C"},
         {1, "Db"},

--- a/src/ChordView.h
+++ b/src/ChordView.h
@@ -41,6 +41,7 @@ private:
     ChordClipper chordClipper;
     void drawChords(ChordVectorType chords, juce::Graphics &g);
     void drawMeasures(MeasurePositionType bars, juce::Graphics &g);
+    bool nameHasSymbols(string chord);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ChordView)
 };

--- a/src/MidiStore.cpp
+++ b/src/MidiStore.cpp
@@ -11,6 +11,7 @@
 
 #include "MidiStore.h"
 #include "ChordName.h"
+#include "MidiChordsTypes.h"
 
 using namespace juce;
 using namespace std;
@@ -656,7 +657,7 @@ vector <pair<float, string>> MidiStore::createStaticView()
     double prevTime = 0.0;
     string prevChord = "";
     ChordName cn;
-    vector<pair<float, string>> newStaticView;
+    ChordVectorType newStaticView;
 
     for (ValueTree::Iterator events = chordState.begin(); events != chordState.end(); ++events)
     {

--- a/tests/chordNameTest.cpp
+++ b/tests/chordNameTest.cpp
@@ -67,10 +67,10 @@ TEST_CASE("two note chords", "chordident")
 
     notes = {0, 3};
     name = cn.nameChord(notes);
-    REQUIRE(name == "Cmin");
+    REQUIRE(name == "Cm");
     notes = {3, 0, 12};
     name = cn.nameChord(notes);
-    REQUIRE(name == "Cmin");
+    REQUIRE(name == "Cm");
     notes = {3, 12};
     name = cn.nameChord(notes);
     REQUIRE(name == "Eb6");
@@ -124,7 +124,7 @@ TEST_CASE("three note chords", "chordident")
     REQUIRE(name == "C");
     notes = {0, 3, 7};
     name = cn.nameChord(notes);
-    REQUIRE(name == "Cmin");
+    REQUIRE(name == "Cm");
     notes = {8, 11, 14};
     name = cn.nameChord(notes);
     REQUIRE(name == "Abdim");
@@ -149,7 +149,7 @@ TEST_CASE("three note chords", "chordident")
     // C#EG# . (the minor 3rd of A major)
     notes = {1, 4, 8};
     name = cn.nameChord(notes);
-    //REQUIRE(name == "C#min");
+    //REQUIRE(name == "C#m");
     // F#A#C# (the V chord of B major)
     notes = {18, 22, 25};
     name = cn.nameChord(notes);
@@ -181,7 +181,7 @@ TEST_CASE("four note chords", "chordident")
     // CGBbD
     notes = {12, 19, 22, 26};
     name = cn.nameChord(notes);
-    REQUIRE(name == "Gmin/C");
+    REQUIRE(name == "Gm/C");
 
     // mlwtbd - need to think about this one. Current code doesn't detect this ... but
     // it seems like maybe it doesn't have an obvious solution. In fact, I guess I'm not sure
@@ -229,4 +229,18 @@ TEST_CASE("test gap rotation", "chordtransform")
     expected = {11, 12, 17};
     REQUIRE(notes == expected);
     REQUIRE(rotated == true);
+}
+
+TEST_CASE("flat sharp", "chordident")
+{
+    ChordName cn;
+
+    optional<string> symbol = cn.getUnicodeSymbol('j');
+    REQUIRE(symbol == std::nullopt);
+    symbol = cn.getUnicodeSymbol('#');
+    REQUIRE(*symbol == "\xe2\x99\xaf");
+    symbol = cn.getUnicodeSymbol('b');
+    REQUIRE(*symbol == "\xe2\x99\xad");
+    symbol = cn.getUnicodeSymbol('n');
+    REQUIRE(*symbol == "\xe2\x99\xae");
 }

--- a/tests/midiStoreTest.cpp
+++ b/tests/midiStoreTest.cpp
@@ -382,14 +382,14 @@ TEST_CASE("view window", "storage")
     REQUIRE(chords == expected);
 
     chords = ms.getChordsInWindow({50.5, 51.3});
-    expected = {{50.5, "Dmin"}};
+    expected = {{50.5, "Dm"}};
     REQUIRE(chords == expected);
 
     chords = ms.getChordsInWindow({28.1, 51.3});
-    expected = {{30.4, "F/C"}, {50.5, "Dmin"}};
+    expected = {{30.4, "F/C"}, {50.5, "Dm"}};
     REQUIRE(chords == expected);
     chords = ms.getChordsInWindow({10.1, 51.3});
-    expected = {{10.1, "C"}, {30.4, "F/C"}, {50.5, "Dmin"}};
+    expected = {{10.1, "C"}, {30.4, "F/C"}, {50.5, "Dm"}};
     REQUIRE(chords == expected);
 
     chords = ms.getChordsInWindow({50.6, 100.1});
@@ -427,7 +427,7 @@ TEST_CASE("view update", "storage")
     ms.setLastViewUpdateTime(curTime - 1001);
     ms.updateStaticViewIfOutOfDate();
     chords = ms.getChordsInWindow({10.0, 10.0});
-    expected = {{10.0, "Cmin"}};
+    expected = {{10.0, "Cm"}};
     REQUIRE(chords == expected);
 }
 


### PR DESCRIPTION
Change the chord display to use the Bravura font if available to display flat/sharp with the appropriate unicode symbols.
Also do some cleanup of display of minor (change min to just an 'm' to save space)