### PR TITLE
Add font size control, UI cleanup, hashmarks

### DIFF
--- a/src/ChordView.h
+++ b/src/ChordView.h
@@ -39,6 +39,7 @@ public:
 
 private:
     ChordClipper chordClipper;
+    MidiStore &midiState;
     juce::LookAndFeel_V3 lookAndFeel;
     void drawChords(ChordVectorType chords, juce::Graphics &g);
     void drawMeasures(MeasurePositionType bars, juce::Graphics &g);

--- a/src/MidiStore.cpp
+++ b/src/MidiStore.cpp
@@ -216,7 +216,27 @@ float MidiStore::getShortChordThreshold()
 {
     // default to half a second
     // Allowing up to 5 seconds here, but I'm setting the slider to be less currently
-    return getStateFloatProp(shortChordThresholdProp, 0.5, 0.0, 5.0);
+    return getStateFloatProp(shortChordThresholdProp, 0.5, 0.0, 2.0);
+}
+
+/**
+ * @brief Store the font size of the chord view
+ * 
+ * @param fontSize
+ */
+void MidiStore::setChordNameSize(float fontSize)
+{
+    setStateProp(chordNameSizeProp, fontSize);
+}
+
+/**
+ * @brief Retrieve font size
+ * 
+ * @return float 
+ */
+float MidiStore::getChordNameSize()
+{
+    return getStateFloatProp(chordNameSizeProp, 25, 5.0, 50.0);
 }
 
 /**

--- a/src/MidiStore.h
+++ b/src/MidiStore.h
@@ -53,6 +53,7 @@ public:
     inline static const char* playHeadPositionProp = "playheadPosition";
     inline static const char* viewWidthProp = "viewWidthProp";
     inline static const char* shortChordThresholdProp = "shortChordThresholdProp";
+    inline static const char* chordNameSizeProp = "chordNameSizeProp";
 
 
 
@@ -89,6 +90,8 @@ public:
     float getTimeWidth();
     void setShortChordThreshold(float threshold);
     float getShortChordThreshold();
+    void setChordNameSize(float fontSize);
+    float getChordNameSize();
     void setBPMinute(double bpm);
     optional<double> getBPMinute();
     void setBPMeasure(int bpmeasure);

--- a/src/OptionsComponent.cpp
+++ b/src/OptionsComponent.cpp
@@ -18,11 +18,6 @@ OptionsComponent::OptionsComponent(MidiStore &ms) : midiState(ms)
 
     addAndMakeVisible(propsPanel);
 
-    recordingOnToggle.setButtonText("Record Notes");
-    propsPanel.addAndMakeVisible(&recordingOnToggle);
-    resetChordsButton.setButtonText("Clear Notes!");
-    propsPanel.addAndMakeVisible(&resetChordsButton);
-
     // juce tutorial of interest:  https://docs.juce.com/master/tutorial_slider_values.html
     propsPanel.addAndMakeVisible(&positionOfPlayheadSlider);
     positionOfPlayheadSlider.setRange(1.0, 99.0, 1.0);
@@ -41,11 +36,24 @@ OptionsComponent::OptionsComponent(MidiStore &ms) : midiState(ms)
 
     // Minimum width (in seconds) for chords to display
     propsPanel.addAndMakeVisible(&shortChordSlider);
-    shortChordSlider.setRange(0.0, 2.5, 0.1);
+    shortChordSlider.setRange(0.0, 2.0, 0.1);
     shortChordSlider.setTextValueSuffix(" sec");
     shortChordLabel.attachToComponent(&shortChordSlider, true);
     propsPanel.addAndMakeVisible(shortChordLabel);
     shortChordLabel.setText("Minimum chord", juce::dontSendNotification);
+
+    // Size of the chord name font
+    propsPanel.addAndMakeVisible(&chordFontSizeSlider);
+    chordFontSizeSlider.setRange(5.0, 50.0, 1.0);
+    chordFontSizeSlider.setTextValueSuffix(" font");
+    chordFontSizeLabel.attachToComponent(&chordFontSizeSlider, true);
+    propsPanel.addAndMakeVisible(chordFontSizeLabel);
+    chordFontSizeLabel.setText("Font size", juce::dontSendNotification);
+
+    recordingOnToggle.setButtonText("Record Notes");
+    propsPanel.addAndMakeVisible(&recordingOnToggle);
+    resetChordsButton.setButtonText("Clear Notes!");
+    propsPanel.addAndMakeVisible(&resetChordsButton);
 
     // click handler lambdas
     resetChordsButton.onClick = [this] { resetClick(); };
@@ -60,6 +68,11 @@ OptionsComponent::OptionsComponent(MidiStore &ms) : midiState(ms)
 
     shortChordSlider.onValueChange = [this] { adjustShortChordThreshold(shortChordSlider.getValue()); };
     shortChordSlider.setValue(ms.getShortChordThreshold(), juce::sendNotification);
+
+    chordFontSizeSlider.onValueChange = [this] { adjustChordFontSize(chordFontSizeSlider.getValue()); };
+    chordFontSizeSlider.setValue(ms.getChordNameSize(), juce::sendNotification);
+
+    this->resized();
 }
 
 /**
@@ -67,7 +80,6 @@ OptionsComponent::OptionsComponent(MidiStore &ms) : midiState(ms)
  */
 void OptionsComponent::resetClick()
 {
-    DBG("Reset click happened");
     midiState.clear();
 }
 
@@ -97,6 +109,11 @@ void OptionsComponent::adjustShortChordThreshold(double value)
     midiState.setShortChordThreshold(static_cast<float>(value));
 }
 
+void OptionsComponent::adjustChordFontSize(double value)
+{
+    midiState.setChordNameSize(static_cast<float>(value));
+}
+
 void OptionsComponent::recordingClick(bool state)
 {
     midiState.allowStateChange(state);
@@ -114,14 +131,16 @@ void OptionsComponent::resized() // override
     int column;
 
     propsPanel.setBounds(area);
-    // recordingOnToggle.setBounds(resetChordsButton.getBounds().getWidth() + 40, area.getHeight() / 2 - buttonHeight / 2, 100, buttonHeight);
-    recordingOnToggle.setBounds(20, area.getHeight() / 3 - buttonHeight / 2, 100, buttonHeight);
-    resetChordsButton.setBounds(20, area.getHeight() * 2 / 3 - buttonHeight / 2, 100, buttonHeight);
-
-    column = resetChordsButton.getBounds().getWidth() + 150;
+    column = timeWidthLabel.getWidth() + 60;
     positionOfPlayheadSlider.setBounds(column, area.getHeight() / 3 - buttonHeight / 2, 200, buttonHeight);
     timeWidthSlider.setBounds(column, area.getHeight() * 2 / 3 - buttonHeight / 2, 200, buttonHeight);
 
     column += positionOfPlayheadSlider.getBounds().getWidth() + 150;
     shortChordSlider.setBounds(column, area.getHeight() / 3 - buttonHeight / 2, 200, buttonHeight);
+    chordFontSizeSlider.setBounds(column, area.getHeight() * 2 / 3 - buttonHeight / 2, 200, buttonHeight);
+
+    // put these on the right hand side
+    column = area.getWidth() - recordingOnToggle.getWidth() - 40;
+    recordingOnToggle.setBounds(column, area.getHeight() / 3 - buttonHeight / 2, 100, buttonHeight);
+    resetChordsButton.setBounds(column, area.getHeight() * 2 / 3 - buttonHeight / 2, 100, buttonHeight);
 }

--- a/src/OptionsComponent.h
+++ b/src/OptionsComponent.h
@@ -27,6 +27,7 @@ public:
     void adjustPositionPlayhead(double value);
     void adjustTimeWidth(double value);
     void adjustShortChordThreshold(double value);
+    void adjustChordFontSize(double value);
 
     void recordingClick(bool state);
 
@@ -42,6 +43,8 @@ private:
     juce::Slider timeWidthSlider;
     juce::Label shortChordLabel;
     juce::Slider shortChordSlider;
+    juce::Label chordFontSizeLabel;
+    juce::Slider chordFontSizeSlider;
     void paint(juce::Graphics &g) override;
     MidiStore &midiState;
 

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -20,7 +20,8 @@ MidiChordsAudioProcessorEditor::MidiChordsAudioProcessorEditor (MidiChordsAudioP
     : AudioProcessorEditor (&p), juce::Timer(), audioProcessor (p), options(ms), chordView(ms)
 {
     setResizable(true, true);
-    setSize (1000, 400);
+    // To see the debug controls, make the height 400 here
+    setSize (1000, 210);
 
 
     lastTimeStamp.setColour(juce::Label::ColourIds::textColourId, juce::Colours::black);
@@ -70,16 +71,14 @@ void MidiChordsAudioProcessorEditor::timerCallback()
     //    have only one parent, so I suspect that is a simple operation.
     options.refreshControlState();
 
-    // and I cannot remember why this repaint call is here. Early version from one of the tutorials? Is it still needed?
-    repaint();
-
-    std::string info = "";
 
     MidiStore *ms = audioProcessor.getMidiState();
     ms->updateStaticViewIfOutOfDate();
 
     debugInfo1.setText("visible chord count: " + std::to_string(ms->getViewWindowChordCount()), juce::NotificationType::sendNotification);
+
     /*
+    std::string info = "";
     std::vector<int64> eventTimes = ms->getEventTimes();
     for (std::vector<int64>::iterator i = eventTimes.begin(); i != eventTimes.end(); ++i) 
     {
@@ -119,6 +118,10 @@ void MidiChordsAudioProcessorEditor::resized()
     lastTimeStamp.setBounds(10, 10, 100, 30);
     debugInfo1.setBounds(10, 40, getWidth() - 10, 30);
     currentChords.setBounds(10, 70, getWidth() - 10, 60);
+    // Make this bigger to be able to see the debug info. Probably will remove this
+    // stuff at some point
+    int debugInfoSize = 0;
+
     options.setBounds(0, getHeight() - 100, getWidth(), 100);
-    chordView.setBounds(0, getHeight() - 200, getWidth(), 100);
+    chordView.setBounds(0, debugInfoSize + 10, getWidth(), getHeight() - (debugInfoSize + 120));
 }

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -34,9 +34,11 @@ private:
     // access the processor object that created it.
     MidiChordsAudioProcessor& audioProcessor;
 
+    // some debug info placeholders
     juce::Label currentChords;
     juce::Label lastTimeStamp;
     juce::Label debugInfo1;
+
     OptionsComponent options;
     ChordView chordView;
 

--- a/tests/midiStoreTest.cpp
+++ b/tests/midiStoreTest.cpp
@@ -160,6 +160,28 @@ TEST_CASE("test time width prop", "storage")
 
 }
 
+TEST_CASE("test chord size prop", "storage")
+{
+    MidiStore ms;
+    float size;
+
+    // default value
+    size = ms.getChordNameSize();
+    REQUIRE(size == 25.0);
+
+    ms.setChordNameSize(32.0);
+    size = ms.getChordNameSize();
+    REQUIRE(size == 32.0);
+
+    ms.setChordNameSize(150.0);
+    size = ms.getChordNameSize();
+    REQUIRE(size == 25.0);
+    ms.setChordNameSize(0.0);
+    size = ms.getChordNameSize();
+    REQUIRE(size == 25.0);
+}
+
+
 TEST_CASE("empty note slot", "storage")
 {
     MidiStore ms;


### PR DESCRIPTION
#what Add in a font control slider to be able to control the size of the chord names in the display
#what Add hash marks to represent beats within each measure (cuz it looks cool and might be useful)
#what Clean up the UI resizing logic. Hides the debug info unless a code change is made. So total resizing works pretty nicely now.