### PR TITLE
Add an about box dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(MIDICHORDS VERSION 0.0.1)
+project(MidiChords VERSION 0.1.0) 
+
+# Generate the config file that contains the version info
+configure_file(src/MidiChordsConfig.h.in MidiChordsConfig.h)
+
 
 # If you've installed JUCE somehow (via a package manager, or directly using the CMake install
 # target), you'll need to tell this project that it depends on the installed copy of JUCE. If you've
@@ -52,10 +56,12 @@ juce_add_plugin(MidiChords
 # include all your JUCE module headers; if you're happy to include module headers directly, you
 # probably don't need to call this.
 
-juce_generate_juce_header(MidiChords)
+juce_generate_juce_header(MidiChords) 
 
 include_directories (
-        src
+        src 
+        # This adds the build directory (e.g., build or release) to the include path (makes the MidiChordsConfig.h be found)
+        "${PROJECT_BINARY_DIR}"
 )
 
 # `target_sources` adds source files to a target. We pass the target that needs the sources as the
@@ -72,6 +78,7 @@ target_sources(MidiChords
         src/ChordName.cpp
         src/ChordView.cpp
         src/ChordClipper.cpp
+        src/AboutBox.cpp
         )
 
 # `target_compile_definitions` adds some preprocessor definitions to our target. In a Projucer

--- a/src/AboutBox.cpp
+++ b/src/AboutBox.cpp
@@ -1,0 +1,73 @@
+/**
+ * @file AboutBox.cpp
+ * @author Mark Wilkins
+ * @brief Part of MidiChords project (plugin to display chord names from a MIDI track on playback)
+ * @version 0.1
+ *
+ * @copyright Copyright (c) 2023
+ *
+ */
+
+#include "AboutBox.h"
+#include "MidiChordsConfig.h"
+
+using namespace juce;
+using namespace std;
+
+AboutBox::AboutBox()
+{
+    setSize(400, 200);
+    addAndMakeVisible(title);
+    title.setText("MidiChords", juce::dontSendNotification);
+    title.setFont(juce::Font(16.0f, juce::Font::bold));
+    title.setJustificationType(juce::Justification::centred);
+
+    string s = "version: " + to_string(MidiChords_VERSION_MAJOR);
+    ostringstream ossVersion;
+    ossVersion << "Version " << MidiChords_VERSION_MAJOR << "." << MidiChords_VERSION_MINOR << "." << MidiChords_VERSION_PATCH;
+    string versionStr = ossVersion.str();
+    addAndMakeVisible(version);
+    version.setText(versionStr, juce::dontSendNotification);
+    version.setJustificationType(juce::Justification::centred);
+
+    addAndMakeVisible(myOwnName);
+
+    myOwnName.setText("Copyright \xa9 2023, Mark Wilkins", juce::dontSendNotification);
+    myOwnName.setJustificationType(juce::Justification::centred);
+    addAndMakeVisible(myGitLink);
+    myGitLink.setButtonText("https://github.com/markwilkins/midi-chord-reader");
+    myGitLink.setURL(URL("https://github.com/markwilkins/midi-chord-reader"));
+
+    addAndMakeVisible(juceAttribution);
+    juceAttribution.setText("Built with JUCE", juce::dontSendNotification);
+    juceAttribution.setJustificationType(juce::Justification::centred);
+    addAndMakeVisible(juceLink);
+    juceLink.setButtonText("https://juce.com");
+    juceLink.setURL(URL("https://juce.com/"));
+}
+
+void AboutBox::paint(juce::Graphics &g)
+{
+    g.fillAll(juce::Colours::lightgrey);
+}
+
+void AboutBox::resized() // override
+{
+    auto area = getLocalBounds();
+
+    int yPos = 10;
+    title.setBounds(0, yPos, area.getWidth(), 40);
+    yPos += title.getHeight() + 5;
+    version.setBounds(0, yPos, area.getWidth(), 20);
+    yPos += version.getHeight() + 5;
+    myOwnName.setBounds(0, yPos, area.getWidth(), 20);
+    yPos += version.getHeight() + 2;
+    myGitLink.setBounds(0, yPos, area.getWidth(), 20);
+    yPos += version.getHeight() + 5;
+    juceAttribution.setBounds(0, yPos, area.getWidth(), 20);
+    yPos += version.getHeight() + 2;
+    juceLink.setBounds(0, yPos, area.getWidth(), 20);
+    yPos += version.getHeight() + 5;
+
+
+}

--- a/src/AboutBox.h
+++ b/src/AboutBox.h
@@ -1,0 +1,36 @@
+
+/**
+ * @file AboutBox.h
+ * @author Mark Wilkins
+ * @brief Part of MidiChords project (plugin to display chord names from a MIDI track on playback)
+ * @version 0.1
+ * 
+ * @copyright Copyright (c) 2023
+ * 
+ */
+
+
+#pragma once
+
+#include <JuceHeader.h>
+
+/**
+ * @brief Provide a set of controls for affecting the behavior of the plugin
+ */
+class AboutBox : public juce::Component
+{
+public:
+    AboutBox();
+
+private:
+    juce::Label title;
+    juce::Label version;
+    juce::Label myOwnName;
+    juce::HyperlinkButton myGitLink;
+    juce::Label juceAttribution;
+    juce::HyperlinkButton juceLink;
+
+    void paint(juce::Graphics &g) override;
+    void resized() override;
+
+};

--- a/src/MidiChordsConfig.h.in
+++ b/src/MidiChordsConfig.h.in
@@ -1,0 +1,4 @@
+// This is used by cmake. Results in a file in the build dir of name MidiChordsConfig.h
+#define MidiChords_VERSION_MAJOR @MidiChords_VERSION_MAJOR@
+#define MidiChords_VERSION_MINOR @MidiChords_VERSION_MINOR@
+#define MidiChords_VERSION_PATCH @MidiChords_VERSION_PATCH@

--- a/src/OptionsComponent.cpp
+++ b/src/OptionsComponent.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "OptionsComponent.h"
+#include "AboutBox.h"
 
 using namespace juce;
 
@@ -79,6 +80,10 @@ OptionsComponent::OptionsComponent(MidiStore &ms) : midiState(ms)
     chordFontSizeSlider.onValueChange = [this] { adjustChordFontSize(chordFontSizeSlider.getValue()); };
     chordFontSizeSlider.setValue(ms.getChordNameSize(), juce::sendNotification);
 
+    propsPanel.addAndMakeVisible(&aboutBoxButton);
+    aboutBoxButton.setButtonText("About...");
+    aboutBoxButton.onClick = [this] { showAboutBox(); };
+
     this->resized();
 }
 
@@ -140,6 +145,11 @@ void OptionsComponent::recordingClick(bool state)
     midiState.allowStateChange(state);
 }
 
+void OptionsComponent::showAboutBox()
+{
+    DialogWindow::showDialog("", &aboutBox, nullptr, Colours::white, true, false, false);
+}
+
 void OptionsComponent::paint(juce::Graphics &g) // override
 {
     propsPanel.setColour(juce::GroupComponent::ColourIds::outlineColourId, juce::Colours::lightgrey);
@@ -166,5 +176,8 @@ void OptionsComponent::resized() // override
     // put these on the right hand side
     column = area.getWidth() - recordingOnToggle.getWidth() - 40;
     recordingOnToggle.setBounds(column, area.getHeight() / 3 - buttonHeight / 2, 100, buttonHeight);
-    resetChordsButton.setBounds(column, area.getHeight() * 2 / 3 - buttonHeight / 2, 100, buttonHeight);
+    resetChordsButton.setBounds(column, area.getHeight() * 2 / 3 - buttonHeight / 2, 100, 30);
+
+    aboutBoxButton.setOpaque(false);
+    aboutBoxButton.setBounds(0, area.getHeight() - 15, 50, 15);
 }

--- a/src/OptionsComponent.h
+++ b/src/OptionsComponent.h
@@ -13,6 +13,7 @@
 
 #include <JuceHeader.h>
 #include "MidiStore.h"
+#include "AboutBox.h"
 
 /**
  * @brief Provide a set of controls for affecting the behavior of the plugin
@@ -28,12 +29,15 @@ public:
     void adjustTimeWidth(double value);
     void adjustShortChordThreshold(double value);
     void adjustChordFontSize(double value);
+    void showAboutBox();
 
     void recordingClick(bool state);
+
 
     void refreshControlState();
 
 private:
+    MidiStore &midiState;
     juce::GroupComponent propsPanel;
     juce::TextButton resetChordsButton;
     juce::ToggleButton recordingOnToggle;
@@ -45,9 +49,10 @@ private:
     juce::Slider shortChordSlider;
     juce::Label chordFontSizeLabel;
     juce::Slider chordFontSizeSlider;
-    void paint(juce::Graphics &g) override;
-    MidiStore &midiState;
+    juce::TextButton aboutBoxButton;
+    AboutBox aboutBox;
 
+    void paint(juce::Graphics &g) override;
     void resized() override;
     void setSliderColors(juce::Slider &slider);
 

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -76,7 +76,6 @@ private:
     juce::String programName = "";
     double currentSampleRate = 0.0;
     int currentSamplesPerBlock;
-    juce::MemoryBlock *stateInfo = nullptr;
 
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MidiChordsAudioProcessor)


### PR DESCRIPTION
#what Add an about box with a small button to get to it from the control panel. Provides links to this github repo and to the juce web site for attribution purposes.