### PR TITLE
Add a basic installer and build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ build/
 release/
 
 Testing/
+instimages/
 
 .vscode/launch.json
 .vscode/settings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(MidiChords VERSION 0.1.0) 
+project(MidiChords VERSION 0.8.0) 
 
 # Generate the config file that contains the version info
 configure_file(src/MidiChordsConfig.h.in MidiChordsConfig.h)
@@ -25,7 +25,7 @@ FetchContent_MakeAvailable(JUCE)
 # If you are building a VST2 or AAX plugin, CMake needs to be told where to find these SDKs on your
 # system. This setup should be done before calling `juce_add_plugin`.
 
-juce_set_vst2_sdk_path("build/_deps/juce-src/modules/juce_audio_processors/format_types/VST3_SDK")
+juce_set_vst3_sdk_path("build/_deps/juce-src/modules/juce_audio_processors/format_types/VST3_SDK")
 # juce_set_aax_sdk_path(...)
 
 # `juce_add_plugin` adds a static library target with the name passed as the first argument

--- a/install/Distribution.xml
+++ b/install/Distribution.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<installer-script>
+    <options/>
+    <title>MidiChords</title>
+    <choices-outline>
+        <line choice="installer_choice_1"/>
+        <line choice="installer_choice_2"/>
+    </choices-outline>
+    <choice id="installer_choice_1" title="MidiChords AU" description="">
+        <pkg-ref id="com.tetrachord.pkg.AU"/>
+    </choice>
+    <choice id="installer_choice_2" title="MidiChords VST3" description="">
+        <pkg-ref id="com.tetrachord.pkg.VST3"/>
+    </choice>
+	<pkg-ref id="com.tetrachord.pkg.AU">MidiChords_AU.pkg</pkg-ref>
+	<pkg-ref id="com.tetrachord.pkg.VST3">MidiChords_VST3.pkg</pkg-ref>
+</installer-script>

--- a/install/buildinst.sh
+++ b/install/buildinst.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# I lifted these commands and basics from this Juce forum post:
+# https://forum.juce.com/t/vst-installer/16654/15?page=2
+
+name="MidiChords"
+version="0.8.0"
+
+mkdir au
+cp -R ~/Library/Audio/Plug-Ins/Components/$name.component au
+
+mkdir vst3/
+cp -R ~/Library/Audio/Plug-Ins/VST3/${name}.vst3 vst3
+
+pkgbuild --analyze --root "./vst3/" "${name}_VST3.plist" \
+
+pkgbuild --analyze --root "./au/" "${name}_AU.plist"
+
+pkgbuild --root "./vst3/" --component-plist "./${name}_VST3.plist" --identifier "com.tetrachord.pkg.VST3" --version $version --install-location "/Library/Audio/Plug-Ins/VST3" "${name}_VST3.pkg"
+
+pkgbuild --root "./au/" --component-plist "./${name}_AU.plist" --identifier "com.tetrachord.pkg.AU" --version $version --install-location "/Library/Audio/Plug-Ins/Components" "${name}_AU.pkg"
+
+
+# Need to work on this ... and maybe have to pay for apple dev membership. Or look at:
+#         https://security.stackexchange.com/questions/17909/how-to-create-an-apple-installer-package-signing-certificate
+# productbuild --distribution "./Distribution.xml" --package-path "./" --resources "./Resources" --sign "Developer ID Installer: Tetrachord" "${name}_${version}.pkg"
+# This builds it without signing. 
+installfile="${name}_${version}.pkg"
+productbuild --distribution "./Distribution.xml" --package-path "./" --resources "./Resources" ${installfile}
+
+# build a file with the checksums using md5 and sha256 for verification
+md5hashvalue=$(md5 ${installfile} | awk '{print $4}')
+shahashvalue=$(shasum -a 256 ${installfile} | awk '{print $1}')
+echo "Checksum of ${installfile}" > hashes.txt
+echo "MD5: ${md5hashvalue}" >> hashes.txt
+echo "SHA256: ${shahashvalue}" >> hashes.txt
+
+# move the install image stuff
+mkdir -p ../instimages
+mv ${installfile} ../instimages
+mv hashes.txt ../instimages
+
+
+# cleanup
+rm "${name}_VST3.plist"
+rm "${name}_AU.plist"
+rm "${name}_VST3.pkg"
+rm "${name}_AU.pkg"
+rm -r "./vst3"
+rm -r "./au"

--- a/install/fullbuild.sh
+++ b/install/fullbuild.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+
+# store current folder
+pushd .
+
+# do release build
+mkdir -p ../release
+cd ../release
+cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake --build .
+ctest -j50 --output-on-failure
+
+# return to install folder
+popd
+./buildinst.sh


### PR DESCRIPTION
#what Create a basic installer for the plugins
#why If someone wants to use this without building it themselves, this *might* be easier.

The issue is that I have not signed the installer. I don't have a developer subscription with Apple and am not inclined to pay the $99 for this given that I am likely the only user in the world. If, for some reason, people find it useful and discover it (how?) then I may pony up for the developer stuff and build a proper installer.

