### PR TITLE
Support mouse scrollable view window

### DIFF
--- a/src/ChordClipper.cpp
+++ b/src/ChordClipper.cpp
@@ -52,6 +52,25 @@ void ChordClipper::updateCurrentPosition(int msSinceLastUpdate)
             this->estimatedPlayPosition = this->estimatedPlayPosition + static_cast<float>(msSinceLastUpdate / 1000.0);
         }
     }
+}
+
+/**
+ * @brief Handle a mouse event for moving the window
+ * This accepts a relative offset (a value -1 < x < 1) that is a scaling factor to move the window
+ * It only moves if not currently in playback.
+ * 
+ * @param float deltaX Relative distance to move the view
+ */
+void ChordClipper::scrollWheelNudge(float deltaX) 
+{
+    // Only do the update if not currently playing ... otherwise it is a battle between the person and the computer and
+    // the computer wins and it just messes with the smooth play otherwise
+    if (!midiState.getIsPlaying())
+    {
+        float width = this->getViewWidthInSeconds();
+        float currentPos = this->estimatedPlayPosition;
+        this->estimatedPlayPosition = currentPos + deltaX * width;
+    }
 
 }
 

--- a/src/ChordClipper.h
+++ b/src/ChordClipper.h
@@ -30,6 +30,7 @@ public:
     MeasurePositionType getMeasuresToDisplay();
     void updateCurrentPosition(int msSinceLastUpdate);
 
+    void scrollWheelNudge(float deltaX);
 
     float getViewWidthInSeconds();
     float getCurrentNotePosition();

--- a/src/ChordView.cpp
+++ b/src/ChordView.cpp
@@ -211,3 +211,25 @@ bool ChordView::checkForBravura()
 void ChordView::resized()
 {
 }
+
+/**
+ * @brief Handle the mouse wheel event (e.g., a two-finger slide on the mouse pad, etc.)
+ * This sends the delta of the X direction to the chord clipper class. It adjusts the playhead accordingly
+ * 
+ * @param MouseEvent &event 
+ * @param MouseWheelDetails wheel 
+ */
+void ChordView::mouseWheelMove(const MouseEvent &event __attribute__((unused)), const MouseWheelDetails &wheel)
+{
+    // DBG("wheel info: x delta: " + to_string(wheel.deltaX) + "  rev: " + to_string(wheel.isReversed) + " inertia: " + to_string(wheel.isInertial) + " smooth: " + to_string(wheel.isSmooth));
+
+    // The scaling here is purely subjective. It seemed a little twitchy without scaling it down some. Dividing
+    // by 3 seems to produce a balance between ability to move a good distance easily and fine control. I determined 
+    // this with a vast amount of testing (one laptop with one DAW with one mouse and one trackpad ... so, yeah, ymmv)
+    // The negation here is to get it to move in a direction consistent with system settings. The MouseWheelDetails
+    // does have a field indicating if it is reversed. But the deltaX values come in adjusted based on the settings
+    // (e.g., natural scroll on a mac). So JUCE is apparently handling that higher in the stack. So no need to check 
+    // the isReversed here.
+    float deltaX = -(wheel.deltaX / 3.0f);
+    chordClipper.scrollWheelNudge(deltaX);
+}

--- a/src/ChordView.h
+++ b/src/ChordView.h
@@ -37,6 +37,8 @@ public:
 
     void resized() override;
 
+    void mouseWheelMove(const MouseEvent &event, const MouseWheelDetails &wheel) override;
+
 private:
     // flag that indicates if the bravura font available (for flat/sharp symbols)
     bool symbolFontAvailable = false;

--- a/tests/chordClipperTest.cpp
+++ b/tests/chordClipperTest.cpp
@@ -213,3 +213,42 @@ TEST_CASE("measure bars", "chordview")
     expected = addMeasureNumbers(3, {2, 5, 8, 11, 14, 17});
     REQUIRE(bars == expected);
 }
+
+
+TEST_CASE("mouse nudge", "chordview")
+{
+    MidiStore ms;
+    ChordClipper cp(ms);
+    ChordVectorType chords;
+    ChordVectorType expected;
+
+    ms.setTimeWidth(10.0);
+    ms.setPlayHeadPosition(0.0);
+    
+    addNote(ms, 1.0, 1.0, 12);  // C
+    addNote(ms, 13.0, 1.0, 17);  // F
+    ms.setLastEventTimeInSeconds(1.0);
+    
+    chords = cp.getChordsToDisplay();
+    expected = {{1, "C"}};
+    REQUIRE(chords == expected);
+
+    // A nudge while playing should not move it
+    ms.setIsPlaying(true);
+    cp.scrollWheelNudge(0.5);
+    chords = cp.getChordsToDisplay();
+    REQUIRE(chords == expected);
+
+    // If not playing, a nudge of 0.5 should move it half of the width (5 seconds since we set width to 10.0 above)
+    ms.setIsPlaying(false);
+    cp.scrollWheelNudge(0.5);
+    chords = cp.getChordsToDisplay();
+    expected = {{8, "F"}};
+    REQUIRE(chords == expected);
+
+    // negative nudge
+    cp.scrollWheelNudge(-0.5);
+    chords = cp.getChordsToDisplay();
+    expected = {{1, "C"}};
+    REQUIRE(chords == expected);
+}


### PR DESCRIPTION
#what Add a listener for mouse scroll (wheel) events and move the view window accordingly.
#why Sometimes I want to see the chords that are not currently visible. 

This ignores the events if currently in playback (no point in fighting the constant updates with a mouse movement). If it is currently stopped, then moves the window by the delta of the event, which is treated as a ratio of the window size.

The behavior depends on the system settings (mouse intertia, natural/reverse movement). The info provided by JUCE seems to obey those settings, so this change is super simple: Listen for the event, adjust the current position by that given proportion of the window. Literally about 10 lines of code. The test was much harder to write.